### PR TITLE
Les oeuvres avec des ID innexistants ne sont plus affichées

### DIFF
--- a/modeles/commentaire.dao.php
+++ b/modeles/commentaire.dao.php
@@ -205,10 +205,10 @@ class CommentaireDAO
             
             if ($type === 'TV') {
                 $oeuvre = $oaDao->findSerie($tmdbId);
-                $commentaire['titreOeuvre'] = $oeuvre ? $oeuvre->getNom() : "Série inconnue";
+                $commentaire['titreOeuvre'] = $oeuvre ? $oeuvre->getNom() : null;
             } else { 
                 $oeuvre = $oaDao->find($tmdbId);
-                $commentaire['titreOeuvre'] = $oeuvre ? $oeuvre->getNom() : "Titre inconnu";
+                $commentaire['titreOeuvre'] = $oeuvre ? $oeuvre->getNom() : null;
             }
             
             $commentaire['backdropOeuvre'] = $oeuvre ? $oeuvre->getBackdropPath() : null;

--- a/modeles/oa.dao.php
+++ b/modeles/oa.dao.php
@@ -221,7 +221,7 @@ class OADao
     {
         return new OA(
             $data['id'] ?? null,
-            $data['title'] ?? 'Titre inconnu',
+            $data['title'] ?? null,
             $data['vote_average'] ?? 0.0,
             'Film',
             $data['overview'] ?? 'Description non disponible',
@@ -361,14 +361,14 @@ class OADao
             if (isset($data['title'])) {
                 return [
                     'idOa'       => $data['id'] ?? null,
-                    'nom'        => $data['title'] ?? 'Titre inconnu',
+                    'nom'        => $data['title'] ?? null,
                     'posterPath' => $this->getPosterUrl($data['poster_path'] ?? null),
                     'type'       => 'Film'
                 ];
             } elseif (isset($data['name'])) {
                 return [
                     'idOa'       => $data['id'] ?? null,
-                    'nom'        => $data['name'] ?? 'Titre inconnu',
+                    'nom'        => $data['name'] ?? null,
                     'posterPath' => $this->getPosterUrl($data['poster_path'] ?? null),
                     'type'       => 'TV'
                 ];
@@ -395,7 +395,7 @@ class OADao
         return array_map(function ($data) {
             return [
                 'idOa' => $data['id'] ?? null,
-                'nom' => $data['name'] ?? 'Titre inconnu',
+                'nom' => $data['name'] ?? null,
                 'posterPath' => $this->getPosterUrl($data['poster_path'] ?? null),
                 'type' => 'TV',
             ];
@@ -438,7 +438,7 @@ class OADao
     {
         return new OA(
             $data['id'] ?? null,
-            $data['name'] ?? 'Titre inconnu',
+            $data['name'] ?? null,
             $data['vote_average'] ?? 0.0,
             'TV',
             $data['overview'] ?? 'Description non disponible',

--- a/templates/recherche.html.twig
+++ b/templates/recherche.html.twig
@@ -3,16 +3,16 @@
 {% block content1 %}
 <a href="javascript:history.back()" class="btn btn-primary mt-2 ms-2 ilFautPatienter">Retour</a>
 
-{# Filtrer les œuvres sans posterPath #}
 {% set oasFiltered = [] %}
-{% for oa in oas %}
-  {% if oa.posterPath is not empty %}
-    {% set oasFiltered = oasFiltered|merge([oa]) %}
-  {% endif %}
-{% endfor %}
+{% if oas is defined and oas is not empty %}
+  {% for oa in oas %}
+    {% if oa.posterPath is defined and oa.posterPath is not empty and oa.posterPath != 'https://via.placeholder.com/500x750?text=Image+non+disponible' %}
+      {% set oasFiltered = oasFiltered|merge([oa]) %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
 
 <div class="container my-4">
-  <!-- Barre de navigation des onglets -->
   <div class="row mb-4">
   <div class="col-12 d-flex flex-wrap justify-content-center">
     <button id="btnGeneral" class="btn btn-primary m-1">Général</button>
@@ -22,7 +22,7 @@
   </div>
   </div>
 
-  <!-- SECTION GÉNÉRAL : 4 films/séries, 4 forums, 4 utilisateurs -->
+  <!-- SECTION GÉNÉRAL :-->
   <div id="sectionGeneral">
   <h3 class="my-3">Films / Séries</h3>
   <div class="row">


### PR DESCRIPTION
## Summary by Sourcery

Prevents the display of works with missing or invalid data, such as non-existent IDs or missing titles, improving data integrity and user experience.

Bug Fixes:
- Fixes an issue where works with missing poster paths or titles were displayed.
- Ensures that only works with valid poster paths are displayed in the search results.
- Prevents 'Unknown Title' from being displayed when a work's title is missing.